### PR TITLE
Bugfix: Negate slope in move_line handler

### DIFF
--- a/code.js
+++ b/code.js
@@ -156,7 +156,7 @@ function moved_line(line) {
     var intercept = line_plane._planeY(line.getIntercept());
     console.log("Slope:", slope);
 
-    point.setLeft(point_plane._nativeX(slope));
+    point.setLeft(point_plane._nativeX(-slope));
     point.setTop(point_plane._nativeY(-intercept));
 
     // This probably shouldn't be needed, but it seems like it is


### PR DESCRIPTION
Fix a small sign-bug in the handler for the moving lines. Probably best shown through the video below:


https://user-images.githubusercontent.com/1533747/142220034-23c9d7d0-9922-4fce-8f6b-03ad3d30a155.mp4

